### PR TITLE
Support relative paths in AdditionalIncludeDirectories

### DIFF
--- a/IncludeToolboxShared/Util/VCUtil.cs
+++ b/IncludeToolboxShared/Util/VCUtil.cs
@@ -108,10 +108,12 @@ namespace IncludeToolbox
             var cl = cfg?.Rules;
             if (cl == null) { VS.MessageBox.ShowErrorAsync("IWYU Error:", "Failed to gather Compiler info.").FireAndForget(); return null; }
 
+            VCDebugSettings debug = (VCDebugSettings)cfg.DebugSettings;
+            string projectDir = debug.WorkingDirectory.Replace('\\', '/');
+
             var com = (IVCRulePropertyStorage2)cl.Item("CL");
             var xstandard = com.GetEvaluatedPropertyValue("LanguageStandard");
 
-            var projectDir = com.GetEvaluatedPropertyValue("DefiningProjectDirectory").Replace('\\', '/');
             var includes = com.GetEvaluatedPropertyValue("AdditionalIncludeDirectories").Replace('\\', '/')
                 .Split(';').Where(s => !string.IsNullOrWhiteSpace(s))
                 .Select(x => "-I\"" + Path.Combine(projectDir, x) + '\"');

--- a/IncludeToolboxShared/Util/VCUtil.cs
+++ b/IncludeToolboxShared/Util/VCUtil.cs
@@ -111,7 +111,7 @@ namespace IncludeToolbox
             var com = (IVCRulePropertyStorage2)cl.Item("CL");
             var xstandard = com.GetEvaluatedPropertyValue("LanguageStandard");
 
-            var projectDir = com.GetEvaluatedPropertyValue("ProjectDir").Replace('\\', '/');
+            var projectDir = com.GetEvaluatedPropertyValue("DefiningProjectDirectory").Replace('\\', '/');
             var includes = com.GetEvaluatedPropertyValue("AdditionalIncludeDirectories").Replace('\\', '/')
                 .Split(';').Where(s => !string.IsNullOrWhiteSpace(s))
                 .Select(x => "-I\"" + Path.Combine(projectDir, x) + '\"');

--- a/IncludeToolboxShared/Util/VCUtil.cs
+++ b/IncludeToolboxShared/Util/VCUtil.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.VCProjectEngine;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using static Microsoft.VisualStudio.VSConstants;
@@ -109,9 +110,11 @@ namespace IncludeToolbox
 
             var com = (IVCRulePropertyStorage2)cl.Item("CL");
             var xstandard = com.GetEvaluatedPropertyValue("LanguageStandard");
+
+            var projectDir = com.GetEvaluatedPropertyValue("ProjectDir").Replace('\\', '/');
             var includes = com.GetEvaluatedPropertyValue("AdditionalIncludeDirectories").Replace('\\', '/')
                 .Split(';').Where(s => !string.IsNullOrWhiteSpace(s))
-                .Select(x => "-I\"" + x + '\"');
+                .Select(x => "-I\"" + Path.Combine(projectDir, x) + '\"');
             var defs = com.GetEvaluatedPropertyValue("PreprocessorDefinitions")
                 .Split(';').Where(s => !string.IsNullOrWhiteSpace(s))
                 .Select(x => "-D" + x);


### PR DESCRIPTION
My repository:

```
Root
--SolutionDir
----solution.sln
----Project1Dir
------Project1.vcxproj
--CodeDir
----Project1Dir
------stdafx.h
------stdafx.cpp
------SomeFolder
--------class.h
--------class.cpp
```


from class.cpp cannot find stdafx.h or other project dirs.
