### PR TITLE
Fix calling IWYU with spaces in the path

### DIFF
--- a/IncludeToolboxShared/IWYU/IWYU.cs
+++ b/IncludeToolboxShared/IWYU/IWYU.cs
@@ -128,8 +128,12 @@ namespace IncludeToolbox.IncludeWhatYouUse
             if (ext == ".h" || ext == ".hpp" || ext == ".hxx")
             {
                 File.WriteAllText(support_cpp_path, "#include \"" + file + "\"");
-                file = " -Xiwyu --check_also=" + file;
+                file = " -Xiwyu --check_also=" + "\"" + file + "\"";
                 file += " \"" + support_cpp_path.Replace("\\", "\\\\") + "\"";
+            }
+            else
+            {
+                file = "\"" + file + "\"";
             }
 
             process.StartInfo.Arguments = $"{command_line} \"@{support_path}\" {file}";


### PR DESCRIPTION
This fixes calling IWYU with parameter "--check_also=" when there are spaces in the file path.
As the path was not quoted, if there were any spaces in the full path, the command will fail to find the file and try to interpret the remainder of the filename as a command.